### PR TITLE
Enforce per-stream FIFO ordering in Postgres outbox

### DIFF
--- a/postgres/outbox/README.md
+++ b/postgres/outbox/README.md
@@ -71,4 +71,16 @@ go ob.Run(ctx)
 
 When the event store appends events, each registered `TransactionHook` is called with the open transaction before it is committed. The outbox inserts one row per event into the outbox table inside that same transaction, so the event rows and outbox rows are always written atomically — either both land or neither does.
 
-The polling loop calls `ProcessNext` on each tick. `ProcessNext` opens its own transaction and selects the oldest unprocessed row using `SELECT FOR UPDATE SKIP LOCKED`, which allows multiple concurrent processors to run without contention. The configured handler is called with the locked row. If the handler returns without error, the row is marked `processed_at = now()` and the transaction is committed. If the handler returns an error, the transaction is rolled back and the row remains available for the next poll cycle.
+The polling loop calls `ProcessNext` on each tick. `ProcessNext` opens its own transaction and selects the next eligible row using `SELECT FOR UPDATE SKIP LOCKED`. The configured handler is called with the locked row. If the handler returns without error, the row is marked `processed_at = now()` and the transaction is committed. If the handler returns an error, the retry count and last error are persisted in the same transaction and the row remains available for the next poll cycle.
+
+## Ordering and Concurrency
+
+`ProcessNext` enforces **strict per-stream FIFO**: an outbox row is only eligible once every earlier row on the same stream has been successfully processed. Concurrent processors (multiple service instances, or multiple goroutines on the same instance) may handle different streams in parallel, but no two callers will ever deliver events for the same stream out of order.
+
+This is implemented in the selection query: in addition to the row-level `FOR UPDATE SKIP LOCKED` claim, each candidate row must have no earlier row on its stream with `processed_at IS NULL`. The partial index `(stream_id, id) WHERE processed_at IS NULL` keeps that lookup cheap.
+
+### Halt on permanent failure
+
+When a row exceeds its configured `WithMaxRetries` budget, it is marked `failed_at = now()` (a "dead letter") and the handler is no longer invoked for it. Because a dead-lettered row still has `processed_at IS NULL`, it continues to act as an unprocessed predecessor and **halts its stream**: no later events on the same stream will be delivered until an operator resolves the failure (typically by setting `processed_at` manually after replaying the event downstream, or by setting `processed_at` and explicitly skipping it). Other streams are unaffected and continue to drain in parallel.
+
+This is the safer default for event-sourced projections, where skipping a single event in a stream's history can leave downstream consumers in a permanently inconsistent state. Operators should monitor `failed_at IS NOT NULL` rows and alert on them.

--- a/postgres/outbox/outbox.go
+++ b/postgres/outbox/outbox.go
@@ -79,7 +79,11 @@ func New(pool *pgxpool.Pool, handler ItemHandler, opts ...Option) (*Outbox, erro
 //	DELETE FROM outbox WHERE failed_at < now() - interval '30 days';
 func (o *Outbox) Schema() string {
 	quotedTable := pgx.Identifier{o.tableName}.Sanitize()
-	quotedIndex := pgx.Identifier{"idx_" + o.tableName + "_unprocessed"}.Sanitize()
+	// Indexed by (stream_id, id) so the head-of-stream NOT EXISTS subquery in
+	// ProcessNext can probe by stream_id. The predicate is processed_at IS NULL
+	// (not also failed_at IS NULL) so that permanently-failed predecessors stay
+	// indexed and continue to block subsequent events on their stream.
+	quotedIndex := pgx.Identifier{"idx_" + o.tableName + "_unprocessed_stream"}.Sanitize()
 	return fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (
     id              bigserial    PRIMARY KEY,
     event_id        uuid         NOT NULL,
@@ -98,8 +102,8 @@ func (o *Outbox) Schema() string {
 );
 
 CREATE INDEX IF NOT EXISTS %s
-    ON %s (id)
-    WHERE processed_at IS NULL AND failed_at IS NULL;
+    ON %s (stream_id, id)
+    WHERE processed_at IS NULL;
 `, quotedTable, quotedIndex, quotedTable)
 }
 

--- a/postgres/outbox/outbox_integration_test.go
+++ b/postgres/outbox/outbox_integration_test.go
@@ -757,22 +757,21 @@ func TestOutbox_RetryAndDeadLetter(t *testing.T) {
 			},
 		},
 		{
-			name: "dead_lettered_items_skipped",
+			name: "dead_letter_halts_affected_stream_only",
 			run: func(t *testing.T, ctx context.Context, db *pgxpool.Pool, strat pgeventstore.Strategy) {
 				t.Helper()
 
-				// Track which event type the handler is called with so we can confirm
-				// event 1 is dead-lettered and event 2 is processed.
+				// Track which event types the handler successfully processes.
 				var mu sync.Mutex
 				processedTypes := make([]string, 0, 2)
 
-				// Handler fails for "event_one", succeeds for "event_two".
+				// Handler fails for "poison" (stream A's first event), succeeds for everything else.
 				handler := func(_ context.Context, item *pgoutbox.Item) error {
+					if item.EventID.Type == "poison" {
+						return fmt.Errorf("poison always fails")
+					}
 					mu.Lock()
 					defer mu.Unlock()
-					if item.EventID.Type == "event_one" {
-						return fmt.Errorf("event_one always fails")
-					}
 					processedTypes = append(processedTypes, item.EventID.Type)
 					return nil
 				}
@@ -781,55 +780,72 @@ func TestOutbox_RetryAndDeadLetter(t *testing.T) {
 				ob := newOutbox(t, ctx, db, handler, pgoutbox.WithMaxRetries(maxRetries))
 				es := newEventStore(t, ctx, db, strat, ob)
 
-				streamID := typeid.NewV4("mystream")
-				appendEvents(t, ctx, es, streamID, []*eventstore.WritableEvent{
-					{Type: "event_one", Data: []byte(`{}`)},
-					{Type: "event_two", Data: []byte(`{}`)},
+				// Two streams: A is poisoned at v1 and should halt; B is healthy and should drain.
+				streamA := typeid.NewV4("streamA")
+				streamB := typeid.NewV4("streamB")
+				appendEvents(t, ctx, es, streamA, []*eventstore.WritableEvent{
+					{Type: "poison", Data: []byte(`{}`)},       // v1 — will be dead-lettered
+					{Type: "after_poison", Data: []byte(`{}`)}, // v2 — must remain blocked
+				})
+				appendEvents(t, ctx, es, streamB, []*eventstore.WritableEvent{
+					{Type: "ok1", Data: []byte(`{}`)},
+					{Type: "ok2", Data: []byte(`{}`)},
 				})
 
-				// Call 1: event_one handler fails, retry_count becomes 1.
-				if err := ob.ProcessNext(ctx); err == nil {
-					t.Fatal("call 1: expected error for event_one, got nil")
+				// Drain everything reachable. The poison row will burn through its retry budget
+				// (2 ProcessNext calls return errors), then get dead-lettered. After that, only
+				// streamB's items remain eligible. Allow extra iterations as a safety margin.
+				for range 10 {
+					if err := ob.ProcessNext(ctx); errors.Is(err, pgoutbox.ErrNoItems) {
+						break
+					}
+					// poison-handler errors are expected; we only care about the final state.
 				}
 
-				// Call 2: event_one retry_count (1) reaches maxRetries (1), so
-				// newRetryCount (2) > maxRetries (1) → dead-lettered.
-				if err := ob.ProcessNext(ctx); err == nil {
-					t.Fatal("call 2: expected error when dead-lettering event_one, got nil")
-				}
-
-				// Call 3: event_one is now skipped; event_two is claimed and processed.
-				if err := ob.ProcessNext(ctx); err != nil {
-					t.Fatalf("call 3: expected event_two to succeed, got: %v", err)
-				}
-
-				// Verify database state.
-				var failedAt *time.Time
-				var processedAt *time.Time
-				var retryCount int
-
+				// streamA's poison row should be dead-lettered.
+				var poisonFailedAt *time.Time
 				if err := db.QueryRow(ctx,
-					`SELECT retry_count, failed_at FROM outbox WHERE event_type = 'event_one'`,
-				).Scan(&retryCount, &failedAt); err != nil {
-					t.Fatalf("querying event_one: %v", err)
+					`SELECT failed_at FROM outbox WHERE event_type = 'poison'`,
+				).Scan(&poisonFailedAt); err != nil {
+					t.Fatalf("querying poison row: %v", err)
 				}
-				if failedAt == nil {
-					t.Error("event_one: expected failed_at to be set, got nil")
+				if poisonFailedAt == nil {
+					t.Error("poison: expected failed_at to be set, got nil")
 				}
 
+				// streamA's after_poison row must NOT have been processed — the stream is halted.
+				var afterPoisonProcessedAt *time.Time
 				if err := db.QueryRow(ctx,
-					`SELECT processed_at FROM outbox WHERE event_type = 'event_two'`,
-				).Scan(&processedAt); err != nil {
-					t.Fatalf("querying event_two: %v", err)
+					`SELECT processed_at FROM outbox WHERE event_type = 'after_poison'`,
+				).Scan(&afterPoisonProcessedAt); err != nil {
+					t.Fatalf("querying after_poison row: %v", err)
 				}
-				if processedAt == nil {
-					t.Error("event_two: expected processed_at to be set, got nil")
+				if afterPoisonProcessedAt != nil {
+					t.Errorf("after_poison: expected stream to be halted, but processed_at = %v", afterPoisonProcessedAt)
 				}
 
+				// streamB's items must both have been processed — its stream is healthy.
+				for _, evType := range []string{"ok1", "ok2"} {
+					var processedAt *time.Time
+					if err := db.QueryRow(ctx,
+						`SELECT processed_at FROM outbox WHERE event_type = $1`, evType,
+					).Scan(&processedAt); err != nil {
+						t.Fatalf("querying %s: %v", evType, err)
+					}
+					if processedAt == nil {
+						t.Errorf("%s: expected processed_at to be set, got nil", evType)
+					}
+				}
+
+				// Final sanity: the handler should have succeeded for exactly ok1 and ok2.
 				mu.Lock()
 				defer mu.Unlock()
-				if len(processedTypes) != 1 || processedTypes[0] != "event_two" {
-					t.Errorf("handler processed types = %v, want [event_two]", processedTypes)
+				if len(processedTypes) != 2 {
+					t.Fatalf("handler processed %d items, want 2 (ok1, ok2): %v", len(processedTypes), processedTypes)
+				}
+				got := map[string]bool{processedTypes[0]: true, processedTypes[1]: true}
+				if !got["ok1"] || !got["ok2"] {
+					t.Errorf("handler processed types = %v, want {ok1, ok2}", processedTypes)
 				}
 			},
 		},
@@ -917,6 +933,120 @@ func TestOutbox_RetryAndDeadLetter(t *testing.T) {
 			tt.run(t, ctx, db, strat)
 		})
 	}
+}
+
+// ---------------------------------------------------------------------------
+// TestOutbox_PerStreamOrdering — Tests per-stream FIFO under concurrent processors
+// ---------------------------------------------------------------------------
+
+func TestOutbox_PerStreamOrdering(t *testing.T) {
+	t.Parallel()
+
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	t.Run("concurrent_processors_preserve_within_stream_order", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+
+		db, err := createPostgresContainer(t, ctx)
+		if err != nil {
+			t.Fatalf("createPostgresContainer: %v", err)
+		}
+
+		strat := must(strategy.NewDefaultStrategy())
+
+		var mu sync.Mutex
+		receivedByStream := make(map[typeid.ID][]int64) // streamID → versions in delivery order
+
+		// Small handler delay encourages goroutines to overlap and race for outbox rows.
+		// If per-stream FIFO weren't enforced, two workers could deliver the same stream's
+		// events out of version order and this test would catch it.
+		handler := func(_ context.Context, item *pgoutbox.Item) error {
+			time.Sleep(15 * time.Millisecond)
+			mu.Lock()
+			defer mu.Unlock()
+			receivedByStream[item.StreamID] = append(receivedByStream[item.StreamID], item.StreamVersion)
+			return nil
+		}
+
+		ob := newOutbox(t, ctx, db, handler)
+		es := newEventStore(t, ctx, db, strat, ob)
+
+		// Three streams with five events each, appended in interleaved order so the
+		// outbox rows for any single stream are spread across non-adjacent ids.
+		streamA := typeid.NewV4("streamA")
+		streamB := typeid.NewV4("streamB")
+		streamC := typeid.NewV4("streamC")
+		streams := []typeid.ID{streamA, streamB, streamC}
+
+		const eventsPerStream = 5
+		for v := 1; v <= eventsPerStream; v++ {
+			for _, sid := range streams {
+				appendEvents(t, ctx, es, sid, []*eventstore.WritableEvent{
+					{Type: "e", Data: fmt.Appendf(nil, `{"v":%d}`, v)},
+				})
+			}
+		}
+
+		totalItems := eventsPerStream * len(streams)
+
+		// Spin up more workers than streams to force contention on stream heads.
+		const workers = 6
+		var wg sync.WaitGroup
+		runCtx, cancel := context.WithCancel(ctx)
+		defer cancel()
+
+		for range workers {
+			wg.Go(func() {
+				for {
+					if runCtx.Err() != nil {
+						return
+					}
+					err := ob.ProcessNext(runCtx)
+					if errors.Is(err, pgoutbox.ErrNoItems) {
+						mu.Lock()
+						done := 0
+						for _, vs := range receivedByStream {
+							done += len(vs)
+						}
+						mu.Unlock()
+						if done >= totalItems {
+							return
+						}
+						// Another worker may still be holding a row in an open tx — back off briefly.
+						time.Sleep(5 * time.Millisecond)
+						continue
+					}
+					if err != nil {
+						t.Errorf("ProcessNext: %v", err)
+						return
+					}
+				}
+			})
+		}
+		wg.Wait()
+
+		mu.Lock()
+		defer mu.Unlock()
+
+		for _, sid := range streams {
+			versions := receivedByStream[sid]
+			if len(versions) != eventsPerStream {
+				t.Errorf("stream %s: received %d events, want %d (versions=%v)",
+					sid, len(versions), eventsPerStream, versions)
+				continue
+			}
+			for i, v := range versions {
+				if v != int64(i+1) {
+					t.Errorf("stream %s: position %d delivered version %d, want %d (full sequence=%v)",
+						sid, i, v, i+1, versions)
+				}
+			}
+		}
+	})
 }
 
 // ---------------------------------------------------------------------------

--- a/postgres/outbox/processor.go
+++ b/postgres/outbox/processor.go
@@ -15,18 +15,24 @@ import (
 // ErrNoItems is returned by ProcessNext when there are no unprocessed outbox items.
 var ErrNoItems = errors.New("no unprocessed outbox items")
 
-// ProcessNext claims and processes the next unprocessed outbox item. It uses
-// SELECT FOR UPDATE SKIP LOCKED so that concurrent processors never handle the
-// same item. If there are no unprocessed items, ErrNoItems is returned.
+// ProcessNext claims and processes the next eligible outbox item.
+//
+// Selection enforces strict per-stream FIFO: a stream's next event is only eligible
+// once every earlier event on that stream has been successfully processed. Concurrent
+// processors may handle different streams in parallel via SELECT FOR UPDATE SKIP LOCKED.
+// If there are no eligible items, ErrNoItems is returned.
 //
 // On handler failure, the item's retry count and last error are persisted within
 // the same transaction (which is then committed), so the failure is recorded even
 // though the item was not successfully processed. If the retry count reaches the
-// configured maximum, the item is permanently marked as failed and will no longer
-// be selected for processing.
+// configured maximum, the item is permanently marked as failed. Because a failed
+// item is still considered an unprocessed predecessor, its stream halts at that
+// point and no later events on that stream will be delivered until an operator
+// resolves the failure.
 //
-// ProcessNext is safe to call concurrently; Postgres row-level locking ensures
-// each item is delivered to at most one caller at a time.
+// ProcessNext is safe to call concurrently; Postgres row-level locking ensures each
+// item is delivered to at most one caller at a time, and the head-of-stream predicate
+// preserves within-stream order across concurrent callers.
 func (o *Outbox) ProcessNext(ctx context.Context) (retErr error) {
 	tx, err := o.pool.Begin(ctx)
 	if err != nil {
@@ -41,14 +47,25 @@ func (o *Outbox) ProcessNext(ctx context.Context) (retErr error) {
 		}
 	}()
 
+	// Only the head of each stream (the lowest-id row with no earlier unprocessed
+	// predecessor on the same stream) is eligible. A permanently-failed predecessor
+	// still has processed_at IS NULL, so it blocks the stream until resolved.
+	table := pgx.Identifier{o.tableName}.Sanitize()
 	query := fmt.Sprintf(
 		`SELECT id, event_id, event_type, stream_id, stream_type, stream_version, timestamp, data, metadata, created_at, retry_count, last_error
-		FROM %s
-		WHERE processed_at IS NULL AND failed_at IS NULL
-		ORDER BY id ASC
+		FROM %[1]s o
+		WHERE o.processed_at IS NULL
+		  AND o.failed_at IS NULL
+		  AND NOT EXISTS (
+		    SELECT 1 FROM %[1]s e
+		    WHERE e.stream_id = o.stream_id
+		      AND e.id < o.id
+		      AND e.processed_at IS NULL
+		  )
+		ORDER BY o.id ASC
 		LIMIT 1
 		FOR UPDATE SKIP LOCKED`,
-		pgx.Identifier{o.tableName}.Sanitize(),
+		table,
 	)
 
 	var item Item


### PR DESCRIPTION
## Summary

- `ProcessNext` now enforces strict per-stream FIFO: a row is eligible only when no earlier row on the same stream has `processed_at IS NULL`. Concurrent processors continue to handle different streams in parallel, but no two callers will ever deliver events for the same stream out of order.
- Dead-lettered rows retain `processed_at IS NULL` and therefore halt their stream until an operator resolves the failure. Other streams are unaffected. This is the safer default for event-sourced projections, where skipping a single event can leave downstream consumers permanently inconsistent.
- The partial index is now `(stream_id, id) WHERE processed_at IS NULL` so the head-of-stream `NOT EXISTS` subquery can probe by `stream_id`, and so permanently-failed predecessors stay indexed and continue to block their stream. The index has been renamed accordingly.

## Breaking change

Previously, a dead-lettered row was skipped and later events on the same stream were still delivered. With this change, a dead-lettered row halts its stream until an operator clears it (typically by setting `processed_at` manually after replaying the event downstream). Operators should monitor `failed_at IS NOT NULL` rows.