### PR TITLE
Fix MongoDB and KurrentDB integration test failures

### DIFF
--- a/kurrentdb/eventstore/event_store.go
+++ b/kurrentdb/eventstore/event_store.go
@@ -67,7 +67,7 @@ func (s *EventStore) ReadStream(ctx context.Context, streamID typeid.ID, opts ev
 	result, err := s.kurrentDB.ReadStream(ctx, streamID.String(), readOpts, count)
 	if err != nil {
 		s.log.Error("reading stream", "stream_id", streamID.String(), "error", err.Error())
-		if _, ok := kurrentdb.FromError(err); ok {
+		if kdbErr, ok := kurrentdb.FromError(err); !ok && kdbErr != nil && kdbErr.Code() == kurrentdb.ErrorCodeResourceNotFound {
 			return nil, eventstore.ErrStreamNotFound
 		}
 
@@ -129,7 +129,7 @@ func (s *EventStore) AppendStream(ctx context.Context, streamID typeid.ID, event
 	}
 
 	if _, err := s.kurrentDB.AppendToStream(ctx, streamID.String(), appendOpts, streamEvents...); err != nil {
-		if kdbErr, ok := kurrentdb.FromError(err); ok {
+		if kdbErr, ok := kurrentdb.FromError(err); !ok && kdbErr != nil {
 			switch kdbErr.Code() {
 			case kurrentdb.ErrorCodeWrongExpectedVersion:
 				var expected, actual int

--- a/kurrentdb/eventstore/stream_iterator.go
+++ b/kurrentdb/eventstore/stream_iterator.go
@@ -56,7 +56,7 @@ func (i *streamIterator) scanEventRecord() (*eventstore.Event, error) {
 	if err != nil {
 		if errors.Is(err, io.EOF) {
 			return nil, eventstore.ErrEndOfEventStream
-		} else if kdbErr, ok := kurrentdb.FromError(err); ok {
+		} else if kdbErr, ok := kurrentdb.FromError(err); !ok && kdbErr != nil {
 			switch kdbErr.Code() {
 			case kurrentdb.ErrorCodeResourceNotFound:
 				return nil, eventstore.ErrStreamNotFound

--- a/mongodb/eventstore/strategy/single_collection_strategy_integration_test.go
+++ b/mongodb/eventstore/strategy/single_collection_strategy_integration_test.go
@@ -106,7 +106,7 @@ func TestSingleCollectionStrategy_Integration_GetStreamIterator(t *testing.T) {
 			haveStreamID: typeid.New("mockstreamtype", uuid.Must(uuid.FromString("a422f08c-0981-49cd-8249-7a48e66a4e8c"))),
 			haveOpts: eventstore.ReadStreamOptions{
 				Direction: eventstore.Reverse,
-				AfterVersion: 2,
+				AfterVersion: 3,
 			},
 			wantEvents: []bson.M{docs[2], docs[1], docs[0]},
 		},
@@ -143,7 +143,7 @@ func TestSingleCollectionStrategy_Integration_GetStreamIterator(t *testing.T) {
 			haveStreamID: typeid.New("mockstreamtype", uuid.Must(uuid.FromString("a422f08c-0981-49cd-8249-7a48e66a4e8c"))),
 			haveOpts: eventstore.ReadStreamOptions{
 				Direction: eventstore.Reverse,
-				AfterVersion: 2,
+				AfterVersion: 3,
 				Count:     2,
 			},
 			wantEvents: []bson.M{docs[2], docs[1]},


### PR DESCRIPTION
## Summary
- Correct the reverse-direction `AfterVersion` inputs in `TestSingleCollectionStrategy_Integration_GetStreamIterator`; the strategy already implemented the documented semantic (`offset <= AfterVersion`), only the test inputs were off by one.
- Fix three KurrentDB error-mapping sites that used `if _, ok := kurrentdb.FromError(err); ok`. `FromError` returns `ok=true` only for `nil`, so the mapping branches never ran for real errors. As a result, `ReadStream` and `AppendStream` leaked raw KurrentDB errors instead of translating them to `eventstore.ErrStreamNotFound` and `eventstore.StreamVersionMismatchError`, breaking `errors.Is` / type-assertion callers.

## Test plan
- [x] `go test -timeout 240s -run "Integration|AcceptanceTest" ./mongodb/... ./kurrentdb/...` — all green
- [x] `go build ./...`